### PR TITLE
Load dev tools middleware last to fix broken redux-thunk

### DIFF
--- a/TemplateProject/app/redux/store.js
+++ b/TemplateProject/app/redux/store.js
@@ -1,12 +1,11 @@
-import { createStore, applyMiddleware, compose } from 'redux';
-import devTools from 'remote-redux-devtools';
+import { createStore, applyMiddleware } from 'redux';
+import { composeWithDevTools } from 'remote-redux-devtools';
 import thunk from 'redux-thunk';
 import rootReducer from './modules';
 
 const store = createStore(
   rootReducer,
-  compose(
-    devTools(),
+  composeWithDevTools(
     applyMiddleware(thunk),
   )
 );


### PR DESCRIPTION
I was scratching my head as to why I couldn't get redux-thunk to work, and after inspecting one of our other apps I discovered that `devTools` needs to be loaded last in order not to break things. I made that change, including a comment which could be useful for documentation purposes.