### PR TITLE
Add test that app renders

### DIFF
--- a/TemplateProject/__mocks__/redux-mock-store.js
+++ b/TemplateProject/__mocks__/redux-mock-store.js
@@ -1,0 +1,7 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+export default mockStore;

--- a/TemplateProject/__tests__/index.js
+++ b/TemplateProject/__tests__/index.js
@@ -1,0 +1,12 @@
+import 'react-native';
+import React from 'react';
+import App from '../app/index';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <App />
+  );
+});

--- a/TemplateProject/app/index.js
+++ b/TemplateProject/app/index.js
@@ -12,4 +12,6 @@ const TemplateProject = () => {
   );
 };
 
+export default TemplateProject;
+
 AppRegistry.registerComponent('TemplateProject', () => TemplateProject);

--- a/TemplateProject/app/redux/modules/__tests__/__snapshots__/counter.js.snap
+++ b/TemplateProject/app/redux/modules/__tests__/__snapshots__/counter.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`decrement 1`] = `
+Object {
+  "value": -1,
+}
+`;
+
+exports[`increment 1`] = `
+Object {
+  "value": 1,
+}
+`;

--- a/TemplateProject/app/redux/modules/__tests__/counter.js
+++ b/TemplateProject/app/redux/modules/__tests__/counter.js
@@ -1,0 +1,9 @@
+import reducer, { INITIAL_STATE, increment, decrement } from '../counter';
+
+test('increment', () => {
+  expect(reducer(INITIAL_STATE, increment())).toMatchSnapshot();
+});
+
+test('decrement', () => {
+  expect(reducer(INITIAL_STATE, decrement())).toMatchSnapshot();
+});

--- a/TemplateProject/app/redux/modules/counter.js
+++ b/TemplateProject/app/redux/modules/counter.js
@@ -4,11 +4,11 @@ const DECREMENT = 'counter/DECREMENT';
 export const increment = () => ({ type: INCREMENT });
 export const decrement = () => ({ type: DECREMENT });
 
-const initialState = {
+export const INITIAL_STATE = {
   value: 0,
 };
 
-export default function reducer(state = initialState, action) {
+export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
     case INCREMENT:
       return { ...state, value: state.value + 1 };

--- a/TemplateProject/jest-setup.js
+++ b/TemplateProject/jest-setup.js
@@ -1,0 +1,35 @@
+// Temporary until https://github.com/facebook/react-native/pull/13049
+jest.mock('Linking', () => {
+  return {
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    openURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
+    canOpenURL: jest.genMockFn().mockReturnValue(Promise.resolve(true)),
+    getInitialURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
+  };
+});
+
+// Temporary until https://github.com/facebook/react-native/pull/13048
+jest.mock('ScrollView', () => {
+  const React = require('React');
+  const View = require('View');
+  const requireNativeComponent = require('requireNativeComponent');
+  const RCTScrollView = requireNativeComponent('RCTScrollView');
+  const ScrollViewComponent = jest.genMockFromModule('ScrollView');
+
+  class ScrollViewMock extends ScrollViewComponent {
+    render() {
+      return (
+        <RCTScrollView {...this.props}>
+          {this.props.refreshControl}
+          <View>
+            {this.props.children}
+          </View>
+        </RCTScrollView>
+      );
+    }
+  }
+
+  return ScrollViewMock;
+});
+

--- a/TemplateProject/package.json
+++ b/TemplateProject/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "jest"
   },
   "dependencies": {
     "react": "15.4.2",
@@ -16,6 +17,7 @@
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
+    "babel-jest": "^19.0.0",
     "babel-eslint": "^7.2.1",
     "babel-preset-react-native": "1.9.1",
     "eslint": "^3.19.0",
@@ -26,6 +28,12 @@
     "remote-redux-devtools": "^0.5.7"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "transformIgnorePatterns": [
+      "node_modules/(?!(jest-)?react-native|react-navigation|react-clone-referenced-element|expo|@expo/*|exponent|@exponent/*)"
+    ],
+    "setupFiles": [
+      "./jest-setup.js"
+    ]
   }
 }

--- a/TemplateProject/package.json
+++ b/TemplateProject/package.json
@@ -17,14 +17,15 @@
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
-    "babel-jest": "^19.0.0",
     "babel-eslint": "^7.2.1",
+    "babel-jest": "^19.0.0",
     "babel-preset-react-native": "1.9.1",
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-react-native": "^2.3.1",
     "jest": "^19.0.2",
     "react-test-renderer": "~15.4.2",
+    "redux-mock-store": "^1.2.2",
     "remote-redux-devtools": "^0.5.7"
   },
   "jest": {

--- a/TemplateProject/yarn.lock
+++ b/TemplateProject/yarn.lock
@@ -786,21 +786,7 @@ babel-template@^6.16.0, babel-template@^6.22.0:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.21.0, babel-traverse@^6.22.0, babel-traverse@^6.22.1:
-  version "6.22.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.22.1.tgz#3b95cd6b7427d6f1f757704908f2fc9748a5f59f"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-    babylon "^6.15.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.23.1:
+babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.22.1, babel-traverse@^6.23.1:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
   dependencies:
@@ -814,16 +800,21 @@ babel-traverse@^6.23.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.21.0, babel-types@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.22.0.tgz#2a447e8d0ea25d2512409e4175479fd78cc8b1db"
+babel-traverse@^6.21.0:
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.22.1.tgz#3b95cd6b7427d6f1f757704908f2fc9748a5f59f"
   dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.22.0"
     babel-runtime "^6.22.0"
-    esutils "^2.0.2"
+    babel-types "^6.22.0"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
     lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
 
-babel-types@^6.23.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
   dependencies:
@@ -832,13 +823,22 @@ babel-types@^6.23.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.14.1, babylon@^6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
+babel-types@^6.21.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.22.0.tgz#2a447e8d0ea25d2512409e4175479fd78cc8b1db"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
 
-babylon@^6.16.1:
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.16.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
+
+babylon@^6.14.1:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -2325,11 +2325,11 @@ istanbul-api@^1.1.0-alpha.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.0.0-alpha, istanbul-lib-coverage@^1.0.0-alpha.0:
+istanbul-lib-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz#f263efb519c051c5f1f3343034fc40e7b43ff212"
 
-istanbul-lib-coverage@^1.0.2:
+istanbul-lib-coverage@^1.0.0-alpha, istanbul-lib-coverage@^1.0.0-alpha.0, istanbul-lib-coverage@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz#87a0c015b6910651cb3b184814dfb339337e25e1"
 
@@ -2339,19 +2339,7 @@ istanbul-lib-hook@^1.0.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.3.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.4.2.tgz#0e2fdfac93c1dabf2e31578637dc78a19089f43e"
-  dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.13.0"
-    istanbul-lib-coverage "^1.0.0"
-    semver "^5.3.0"
-
-istanbul-lib-instrument@^1.6.2:
+istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.3.0, istanbul-lib-instrument@^1.6.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz#b8e0dc25709bb44e17336ab47b7bb5c97c23f659"
   dependencies:
@@ -3617,6 +3605,10 @@ redux-devtools-instrument@^1.3.3:
   dependencies:
     lodash "^4.2.0"
     symbol-observable "^1.0.2"
+
+redux-mock-store@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.2.tgz#38007dc38f12ca8d965c7521afee5ccacc234d03"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Add a simple test that verifies the app renders properly when using the test
renderer. Add the necessary config to make this work.

- Don't attempt to transform libraries that don't need it. The `expo` ones
  aren't totally necessary at this point, but since their libraries are fairly
  popular and being swallowed up by RN proper, I figure it's worth having them
  included so that things work if someone ads one of those to their project.
- Temporarily stub out `Linking` and `ScrollView` since neither are properly
  stubbed by default in RN. Reference the open PRs so we can track them and
  remove once they are shipped.