### PR TITLE
Automatically set build number/version code

### DIFF
--- a/TemplateProject/android/app/build.gradle
+++ b/TemplateProject/android/app/build.gradle
@@ -88,6 +88,14 @@ def enableSeparateBuildPerCPUArchitecture = false
  */
 def enableProguardInReleaseBuilds = false
 
+def commitCount() {
+  'git rev-list --count master'
+    .execute([], project.rootDir)
+    .text
+    .trim()
+    .toInteger()
+}
+
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.1"
@@ -96,7 +104,7 @@ android {
         applicationId "com.templateproject"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1
+        versionCode commitCount()
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/TemplateProject/ios/TemplateProject.xcodeproj/project.pbxproj
+++ b/TemplateProject/ios/TemplateProject.xcodeproj/project.pbxproj
@@ -487,6 +487,7 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				F8A499501EF9C099004BEEC5 /* Set build number */,
 			);
 			buildRules = (
 			);
@@ -799,6 +800,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+		};
+		F8A499501EF9C099004BEEC5 /* Set build number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set build number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git=$(sh /etc/profile; which git)\nnumber_of_commits=$(\"$git\" rev-list --count master | tr -d ' ')\ntarget_plist=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\ndsym_plist=\"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist\"\n\nfor plist in \"$target_plist\" \"$dsym_plist\"; do\nif [ -f \"$plist\" ]; then\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $number_of_commits\" \"$plist\"\nfi\ndone";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/{{cookiecutter.directory_name}}/android/app/build.gradle
+++ b/{{cookiecutter.directory_name}}/android/app/build.gradle
@@ -88,6 +88,14 @@ def enableSeparateBuildPerCPUArchitecture = false
  */
 def enableProguardInReleaseBuilds = false
 
+def commitCount() {
+  'git rev-list --count master'
+    .execute([], project.rootDir)
+    .text
+    .trim()
+    .toInteger()
+}
+
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.1"
@@ -96,7 +104,7 @@ android {
         applicationId "com.{{cookiecutter.package_name}}"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1
+        versionCode commitCount()
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/{{cookiecutter.directory_name}}/ios/{{cookiecutter.project_name}}.xcodeproj/project.pbxproj
+++ b/{{cookiecutter.directory_name}}/ios/{{cookiecutter.project_name}}.xcodeproj/project.pbxproj
@@ -487,6 +487,7 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				F8A499501EF9C099004BEEC5 /* Set build number */,
 			);
 			buildRules = (
 			);
@@ -799,6 +800,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+		};
+		F8A499501EF9C099004BEEC5 /* Set build number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set build number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git=$(sh /etc/profile; which git)\nnumber_of_commits=$(\"$git\" rev-list --count master | tr -d ' ')\ntarget_plist=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\ndsym_plist=\"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist\"\n\nfor plist in \"$target_plist\" \"$dsym_plist\"; do\nif [ -f \"$plist\" ]; then\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $number_of_commits\" \"$plist\"\nfi\ndone";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This updates the build processes for both Android and iOS so that the
build number (iOS) and version code (Android) are automatically set at
build time based on the number of commits on master. This keeps the
numbers incrementing consistently without any explicit action needing to
be taken by the developer.