### PR TITLE
Reintroduce semicolons

### DIFF
--- a/TemplateProject/.eslintrc.json
+++ b/TemplateProject/.eslintrc.json
@@ -71,7 +71,7 @@
     "object-shorthand": 2,
     "operator-linebreak": [2, "after"],
     "arrow-parens": 0,
-    "semi": [2, "never"],
+    "semi": [2, "always"],
     "space-infix-ops": 2,
     "keyword-spacing": [
       2,

--- a/TemplateProject/.prettierrc
+++ b/TemplateProject/.prettierrc
@@ -1,4 +1,3 @@
 {
-  "semi": false,
   "trailingComma": "es5"
 }

--- a/TemplateProject/__mocks__/redux-mock-store.js
+++ b/TemplateProject/__mocks__/redux-mock-store.js
@@ -1,7 +1,7 @@
-import configureMockStore from "redux-mock-store"
-import thunk from "redux-thunk"
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
 
-const middlewares = [thunk]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
-export default mockStore
+export default mockStore;

--- a/TemplateProject/__tests__/example.test.js
+++ b/TemplateProject/__tests__/example.test.js
@@ -1,3 +1,3 @@
 test("suite is set up correctly", () => {
-  expect(1 + 1).toBe(2)
-})
+  expect(1 + 1).toBe(2);
+});

--- a/TemplateProject/__tests__/index.js
+++ b/TemplateProject/__tests__/index.js
@@ -1,10 +1,10 @@
-import "react-native"
-import React from "react"
-import App from "../app/index"
+import "react-native";
+import React from "react";
+import App from "../app/index";
 
 // Note: test renderer must be required after react-native.
-import renderer from "react-test-renderer"
+import renderer from "react-test-renderer";
 
 it("renders correctly", () => {
-  const tree = renderer.create(<App />)
-})
+  const tree = renderer.create(<App />);
+});

--- a/TemplateProject/app/components/app.js
+++ b/TemplateProject/app/components/app.js
@@ -1,13 +1,13 @@
-import React from "react"
-import { StatusBar, StyleSheet, View } from "react-native"
-import { AppNavigator } from "../routes"
-import styles from "../styles"
+import React from "react";
+import { StatusBar, StyleSheet, View } from "react-native";
+import { AppNavigator } from "../routes";
+import styles from "../styles";
 
 const App = () => (
   <View style={styles.app}>
     <StatusBar barStyle="light-content" />
     <AppNavigator />
   </View>
-)
+);
 
-export default App
+export default App;

--- a/TemplateProject/app/components/index.js
+++ b/TemplateProject/app/components/index.js
@@ -1,3 +1,3 @@
-import App from "./app"
+import App from "./app";
 
-export { App }
+export { App };

--- a/TemplateProject/app/index.js
+++ b/TemplateProject/app/index.js
@@ -1,17 +1,17 @@
-import React from "react"
-import { AppRegistry } from "react-native"
-import { Provider } from "react-redux"
-import { App } from "./components"
-import store from "./redux/store"
+import React from "react";
+import { AppRegistry } from "react-native";
+import { Provider } from "react-redux";
+import { App } from "./components";
+import store from "./redux/store";
 
 const TemplateProject = () => {
   return (
     <Provider store={store}>
       <App />
     </Provider>
-  )
-}
+  );
+};
 
-export default TemplateProject
+export default TemplateProject;
 
-AppRegistry.registerComponent("TemplateProject", () => TemplateProject)
+AppRegistry.registerComponent("TemplateProject", () => TemplateProject);

--- a/TemplateProject/app/redux/modules/__tests__/counter.js
+++ b/TemplateProject/app/redux/modules/__tests__/counter.js
@@ -1,9 +1,9 @@
-import reducer, { INITIAL_STATE, increment, decrement } from "../counter"
+import reducer, { INITIAL_STATE, increment, decrement } from "../counter";
 
 test("increment", () => {
-  expect(reducer(INITIAL_STATE, increment())).toMatchSnapshot()
-})
+  expect(reducer(INITIAL_STATE, increment())).toMatchSnapshot();
+});
 
 test("decrement", () => {
-  expect(reducer(INITIAL_STATE, decrement())).toMatchSnapshot()
-})
+  expect(reducer(INITIAL_STATE, decrement())).toMatchSnapshot();
+});

--- a/TemplateProject/app/redux/modules/counter.js
+++ b/TemplateProject/app/redux/modules/counter.js
@@ -1,20 +1,20 @@
-const INCREMENT = "counter/INCREMENT"
-const DECREMENT = "counter/DECREMENT"
+const INCREMENT = "counter/INCREMENT";
+const DECREMENT = "counter/DECREMENT";
 
-export const increment = () => ({ type: INCREMENT })
-export const decrement = () => ({ type: DECREMENT })
+export const increment = () => ({ type: INCREMENT });
+export const decrement = () => ({ type: DECREMENT });
 
 export const INITIAL_STATE = {
   value: 0,
-}
+};
 
 export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
     case INCREMENT:
-      return { ...state, value: state.value + 1 }
+      return { ...state, value: state.value + 1 };
     case DECREMENT:
-      return { ...state, value: state.value - 1 }
+      return { ...state, value: state.value - 1 };
     default:
-      return state
+      return state;
   }
 }

--- a/TemplateProject/app/redux/modules/index.js
+++ b/TemplateProject/app/redux/modules/index.js
@@ -1,9 +1,9 @@
-import counterReducer from "./counter"
+import counterReducer from "./counter";
 
-const initialState = {}
+const initialState = {};
 
 export default function(state = initialState, action) {
   return {
     counter: counterReducer(state.counter, action),
-  }
+  };
 }

--- a/TemplateProject/app/redux/store.js
+++ b/TemplateProject/app/redux/store.js
@@ -1,20 +1,20 @@
-import { createStore, applyMiddleware } from "redux"
-import { composeWithDevTools } from "remote-redux-devtools"
-import thunk from "redux-thunk"
-import rootReducer from "./modules"
+import { createStore, applyMiddleware } from "redux";
+import { composeWithDevTools } from "remote-redux-devtools";
+import thunk from "redux-thunk";
+import rootReducer from "./modules";
 
 const store = createStore(
   rootReducer,
   composeWithDevTools(applyMiddleware(thunk))
-)
+);
 
 if (module.hot) {
   const acceptCallback = () => {
-    const nextRootReducer = require("./modules").default
-    store.replaceReducer(nextRootReducer)
-  }
-  module.hot.accept("./modules", acceptCallback)
-  module.hot.acceptCallback = acceptCallback
+    const nextRootReducer = require("./modules").default;
+    store.replaceReducer(nextRootReducer);
+  };
+  module.hot.accept("./modules", acceptCallback);
+  module.hot.acceptCallback = acceptCallback;
 }
 
-export default store
+export default store;

--- a/TemplateProject/app/routes.js
+++ b/TemplateProject/app/routes.js
@@ -1,8 +1,8 @@
-import React from "react"
-import { Platform } from "react-native"
-import { StackNavigator, TabNavigator } from "react-navigation"
-import { Counter, Welcome } from "./screens"
-import { colors } from "./styles"
+import React from "react";
+import { Platform } from "react-native";
+import { StackNavigator, TabNavigator } from "react-navigation";
+import { Counter, Welcome } from "./screens";
+import { colors } from "./styles";
 
 const stackConfig = {
   navigationOptions: {
@@ -11,7 +11,7 @@ const stackConfig = {
     },
     headerTintColor: colors.background,
   },
-}
+};
 
 const tabConfig = {
   tabBarOptions: Platform.select({
@@ -25,21 +25,21 @@ const tabConfig = {
       },
     },
   }),
-}
+};
 
 const WelcomeNavigator = StackNavigator(
   {
     Welcome: { screen: Welcome },
   },
   stackConfig
-)
+);
 
 const CounterNavigator = StackNavigator(
   {
     Counter: { screen: Counter },
   },
   stackConfig
-)
+);
 
 const AppNavigator = TabNavigator(
   {
@@ -47,6 +47,6 @@ const AppNavigator = TabNavigator(
     Counter: { screen: CounterNavigator },
   },
   tabConfig
-)
+);
 
-export { AppNavigator }
+export { AppNavigator };

--- a/TemplateProject/app/screens/counter.js
+++ b/TemplateProject/app/screens/counter.js
@@ -1,16 +1,16 @@
-import React, { Component } from "react"
-import { Text, TouchableOpacity, View } from "react-native"
-import { connect } from "react-redux"
-import styles from "../styles"
-import * as counterActions from "../redux/modules/counter"
+import React, { Component } from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+import { connect } from "react-redux";
+import styles from "../styles";
+import * as counterActions from "../redux/modules/counter";
 
 class Counter extends Component {
   static navigationOptions = {
     title: "Counter",
-  }
+  };
 
   render() {
-    const { value, increment, decrement } = this.props
+    const { value, increment, decrement } = this.props;
 
     return (
       <View style={styles.container}>
@@ -24,11 +24,11 @@ class Counter extends Component {
           </TouchableOpacity>
         </View>
       </View>
-    )
+    );
   }
 }
 
 export default connect(({ counter }) => counter, {
   increment: counterActions.increment,
   decrement: counterActions.decrement,
-})(Counter)
+})(Counter);

--- a/TemplateProject/app/screens/index.js
+++ b/TemplateProject/app/screens/index.js
@@ -1,4 +1,4 @@
-import Counter from "./counter"
-import Welcome from "./welcome"
+import Counter from "./counter";
+import Welcome from "./welcome";
 
-export { Counter, Welcome }
+export { Counter, Welcome };

--- a/TemplateProject/app/screens/welcome.js
+++ b/TemplateProject/app/screens/welcome.js
@@ -1,11 +1,11 @@
-import React, { Component } from "react"
-import { Text, View } from "react-native"
-import styles from "../styles"
+import React, { Component } from "react";
+import { Text, View } from "react-native";
+import styles from "../styles";
 
 class Welcome extends Component {
   static navigationOptions = {
     title: "TemplateProject",
-  }
+  };
 
   render() {
     return (
@@ -21,8 +21,8 @@ class Welcome extends Component {
           Cmd+D or shake for dev menu
         </Text>
       </View>
-    )
+    );
   }
 }
 
-export default Welcome
+export default Welcome;

--- a/TemplateProject/app/styles.js
+++ b/TemplateProject/app/styles.js
@@ -1,11 +1,11 @@
-import React from "react"
-import { StyleSheet } from "react-native"
+import React from "react";
+import { StyleSheet } from "react-native";
 
 const colors = {
   primary: "#ed3e44",
   secondary: "#29292c",
   background: "white",
-}
+};
 
 const styles = StyleSheet.create({
   app: {
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
   button: {
     margin: 5,
   },
-})
+});
 
-export { colors }
-export default styles
+export { colors };
+export default styles;

--- a/TemplateProject/index.android.js
+++ b/TemplateProject/index.android.js
@@ -1,1 +1,1 @@
-import "./app/index"
+import "./app/index";

--- a/TemplateProject/index.ios.js
+++ b/TemplateProject/index.ios.js
@@ -1,1 +1,1 @@
-import "./app/index"
+import "./app/index";

--- a/TemplateProject/jest-setup.js
+++ b/TemplateProject/jest-setup.js
@@ -6,16 +6,16 @@ jest.mock("Linking", () => {
     openURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
     canOpenURL: jest.genMockFn().mockReturnValue(Promise.resolve(true)),
     getInitialURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
-  }
-})
+  };
+});
 
 // Temporary until https://github.com/facebook/react-native/pull/13048
 jest.mock("ScrollView", () => {
-  const React = require("React")
-  const View = require("View")
-  const requireNativeComponent = require("requireNativeComponent")
-  const RCTScrollView = requireNativeComponent("RCTScrollView")
-  const ScrollViewComponent = jest.genMockFromModule("ScrollView")
+  const React = require("React");
+  const View = require("View");
+  const requireNativeComponent = require("requireNativeComponent");
+  const RCTScrollView = requireNativeComponent("RCTScrollView");
+  const ScrollViewComponent = jest.genMockFromModule("ScrollView");
 
   class ScrollViewMock extends ScrollViewComponent {
     render() {
@@ -24,9 +24,9 @@ jest.mock("ScrollView", () => {
           {this.props.refreshControl}
           <View>{this.props.children}</View>
         </RCTScrollView>
-      )
+      );
     }
   }
 
-  return ScrollViewMock
-})
+  return ScrollViewMock;
+});


### PR DESCRIPTION
I discovered in #34 that TypeScript kinda requires semicolons for the type definitions to compile, so this PR reintroduces them.