### PR TITLE
Specify node version in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,7 @@ test:
     - bin/generate
   override:
     - bin/test
+
+machine:
+  node:
+    version: 8.9.4


### PR DESCRIPTION
Previously, builds were failing, even a re-build of previously passing `master`. The output from `bin/test` included the following warning which looked like a possible root cause:

```
warning You are using Node "4.2.6" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: "^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0"
```

Sure enough, specifying a recent node version in `circle.yml` gets the build back to green.