### PR TITLE
📚 Document prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,18 @@ We expect everyone to follow the code of conduct
 anywhere in thoughtbot's project codebases,
 issue trackers, chatrooms, and mailing lists.
 
+## Prerequisites
+
+Contributing to React Native Template requires you to install [`rename`]. If
+you're on macOS, you can install `rename` with [Homebrew]:
+
+```
+$ brew install rename
+```
+
+[`rename`]: http://plasmasturm.org/code/rename/
+[Homebrew]: https://brew.sh
+
 ## Contributing Code
 
 Make your change. Follow the [style guide][style].


### PR DESCRIPTION
`rename` was not listed as a prerequisite of the project. The `generate` script fails without this prerequisite. We documented the installation of `rename` as a prerequisite of the project.