### PR TITLE
🐛 Fix CI configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  node:
+    version: 8.12.0
+
 dependencies:
   pre:
     - pip install cookiecutter


### PR DESCRIPTION
The default version of Node.js used by CircleCI (4.2.6) is not compatible with Yarn. Every build was failing because the build could not install ESLint. Fixed the CI configuration to use the most recent version of Node.js 8.