### PR TITLE
Bump fastlane version 2.108.0

### DIFF
--- a/TemplateProject/Gemfile.lock
+++ b/TemplateProject/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.4)
-    fastlane (2.105.0)
+    fastlane (2.108.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -71,10 +71,10 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.9)
-    googleauth (0.6.6)
+    googleauth (0.6.7)
       faraday (~> 0.12)
       jwt (>= 1.4, < 3.0)
-      memoist (~> 0.12)
+      memoist (~> 0.16)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
@@ -105,7 +105,7 @@ GEM
     rouge (2.0.7)
     rubyzip (1.2.2)
     security (0.1.3)
-    signet (0.9.2)
+    signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
@@ -127,7 +127,7 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
     word_wrap (1.0.0)
-    xcodeproj (1.6.0)
+    xcodeproj (1.7.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -145,4 +145,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/{{cookiecutter.directory_name}}/Gemfile.lock
+++ b/{{cookiecutter.directory_name}}/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.4)
-    fastlane (2.105.0)
+    fastlane (2.108.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -71,10 +71,10 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.9)
-    googleauth (0.6.6)
+    googleauth (0.6.7)
       faraday (~> 0.12)
       jwt (>= 1.4, < 3.0)
-      memoist (~> 0.12)
+      memoist (~> 0.16)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
@@ -105,7 +105,7 @@ GEM
     rouge (2.0.7)
     rubyzip (1.2.2)
     security (0.1.3)
-    signet (0.9.2)
+    signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
@@ -127,7 +127,7 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
     word_wrap (1.0.0)
-    xcodeproj (1.6.0)
+    xcodeproj (1.7.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -145,4 +145,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   1.16.5
+   1.17.1


### PR DESCRIPTION
```Your bundle is locked to fastlane (2.105.0), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of fastlane (2.105.0) has removed it. You'll need to update your bundle to a version other than fastlane (2.105.0) that hasn't been removed in order to install.```

`2.105.0` has been removed from fastlane (https://rubygems.org/gems/fastlane/versions/2.105.0), version bump to make things work